### PR TITLE
Remove `python-magic` dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,4 @@ dependencies:
   - cudatoolkit
   - pypdf2
   - python-docx
-  - python-magic
 prefix: C:\Users\dmfro\anaconda3\envs\nocheat

--- a/src/back/Controller.py
+++ b/src/back/Controller.py
@@ -8,7 +8,6 @@ import tempfile
 DOC_FILETYPES = {"application/vnd.openxmlformats-officedocument.wordprocessingml.document"} #,
                  #"application/msword", "application/vnd.oasis.opendocument.text"}
 
-
 def parse_file(file: FileStorage) -> str:
     """
     Takes a text file and moves text into data structure.
@@ -17,8 +16,7 @@ def parse_file(file: FileStorage) -> str:
     :return: A string containing the text from the document
     """
     text = ""
-    filetype = magic.from_buffer(file.stream.read(2048), mime = True)
-    file.stream.seek(0)
+    filetype = file.mimetype
     if filetype == "text/plain":
         text = file.stream.read().decode('utf-8')
     elif filetype == "application/pdf":

--- a/src/test/test_controller.py
+++ b/src/test/test_controller.py
@@ -11,17 +11,17 @@ class TestController(TestCase):
 
     def test_parse_fileTxt(self):
         with open("data/lipsum.txt", 'rb') as t:
-            file = FileStorage(stream=t, filename="data/lipsum.txt")
+            file = FileStorage(stream=t, filename="data/lipsum.txt", content_type="text/plain")
             self.assertEquals(testText, c.parse_file(file))
 
     def test_parse_filePdf(self):
         with open("data/lipsum.pdf", 'rb') as t:
-            file = FileStorage(stream=t, filename="data/lipsum.pdf")
+            file = FileStorage(stream=t, filename="data/lipsum.pdf", content_type="application/pdf")
             self.assertEquals(testText, c.parse_file(file))
 
     def test_parse_fileDocx(self):
         with open("data/lipsum.docx", 'rb') as t:
-            file = FileStorage(stream=t, filename="data/lipsum.docx")
+            file = FileStorage(stream=t, filename="data/lipsum.docx", content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document")
             self.assertEquals(testText, c.parse_file(file))
 
     def test_analyze_results(self):


### PR DESCRIPTION
Since relying on `python-magic` has proven to be difficult, this PR should provide a fix for that by making use of the MIME type provided by the submitted form via `FileStorage.mimetype`, rather than reading the bytes directly.